### PR TITLE
Make layer 2 and layer 3 score more accurate

### DIFF
--- a/src/maturitycalculation.ts
+++ b/src/maturitycalculation.ts
@@ -20,6 +20,8 @@ export function rateProgressiveSummarization(charCountTotal: number, layer2count
 		} else if (percentLayer2 <= 30) {
 			layer2maturity = 3;
 		} else if (percentLayer2 <= 40) {
+			layer2maturity = 2;
+		} else if (percentLayer2 <= 50) {
 			layer2maturity = 1;
 		} else {
 			layer2maturity = 0;
@@ -39,7 +41,7 @@ export function rateProgressiveSummarization(charCountTotal: number, layer2count
 			maturity = 1;
 		} else if (layer2maturity == 2 && layer3maturity == 0) {
 			maturity = 2;
-		} else if (layer2maturity >= 3 && layer3maturity == 0) {
+		} else if ((layer2maturity >= 3 && layer3maturity == 0) || (layer2maturity <= 2 && layer3maturity >= 4)) {
 			maturity = 3;
 		} else if ((layer2maturity == 3 || layer2maturity == 4) && (layer3maturity == 4 || layer3maturity == 5)) {
 			maturity = 4;


### PR DESCRIPTION
The note maturity score when layer 2 score is less than or equal to 2 and layer 3 score is greater than or equal to 4 should be 3, not 0 because when layer 2 score is 2 and layer 3 score is 0, the note maturity score is 2. And added layer 2 maturity score is 2 to make sure all 6 values are there.