### PR TITLE
Increase trust to attached artefacts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+
+    # CRITICAL: Give GitHub the required permissions to sign your files
+    permissions:
+        id-token: write
+        contents: read
+        attestations: write
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
@@ -31,3 +38,20 @@ jobs:
             main.js
             manifest.json
 
+        # 6. Generate the cryptographic attestations for your built files
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+            subject-path: 'dist/*'
+
+        # 7. Automatically create a GitHub Release and attach the files
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+            generate_release_notes: true
+            files: |
+                dist/main.js
+                dist/styles.css
+                dist/manifest.json
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,6 +38,7 @@ jobs:
           path: |
             main.js
             manifest.json
+            styles.css
 
         # 5. Archive verified build (Matches root directory)
       - name: Archive verified build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,11 +38,24 @@ jobs:
             main.js
             manifest.json
 
+        # 5. Archive verified build (Matches root directory)
+      - name: Archive verified build
+        uses: actions/upload-artifact@v4.6.2
+        with:
+            name: dist-verified
+            path: |
+                main.js
+                manifest.json
+                styles.css
+
         # 6. Generate the cryptographic attestations for your built files
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v2
         with:
-            subject-path: 'dist/*'
+            subject-path: |
+                main.js
+                manifest.json
+                styles.css
 
         # 7. Automatically create a GitHub Release and attach the files
       - name: Create GitHub Release
@@ -50,8 +63,8 @@ jobs:
         with:
             generate_release_notes: true
             files: |
-                dist/main.js
-                dist/styles.css
-                dist/manifest.json
+                main.js
+                styles.css
+                manifest.json
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: dist-verified
+          overwrite: true
           path: |
             main.js
             manifest.json

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -58,14 +58,15 @@ jobs:
                 manifest.json
                 styles.css
 
-        # 7. Automatically create a GitHub Release and attach the files
+          # 7. Automatically create a GitHub Release
       - name: Create GitHub Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' # Only release on main
         uses: softprops/action-gh-release@v2
         with:
             generate_release_notes: true
             files: |
                 main.js
-                styles.css
                 manifest.json
+                styles.css
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,15 +40,6 @@ jobs:
             manifest.json
             styles.css
 
-        # 5. Archive verified build (Matches root directory)
-      - name: Archive verified build
-        uses: actions/upload-artifact@v4.6.2
-        with:
-            name: dist-verified
-            path: |
-                main.js
-                manifest.json
-                styles.css
 
         # 6. Generate the cryptographic attestations for your built files
       - name: Attest Build Provenance


### PR DESCRIPTION
By adding building by git workflow and add it to release, trust is increased compiled file is doing what checked in source code is programmed for. 