### PR TITLE
Hot-fix saving data when initialising - Choose selection logic

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "gamified-pkm",
   "name": "Gamificate your PKM",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "minAppVersion": "0.15.0",
   "description": "Enhance your Personal Knowledge Management with gamification elements. Boost motivation and achieve growth as you engage with your PKM.",
   "author": "Andreas Trebing",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-gamified-pkm",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-gamified-pkm",
-      "version": "0.0.105",
+      "version": "0.0.106",
       "license": "MIT",
       "dependencies": {
         "chart.js": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-gamified-pkm",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "description": "Enhance your Personal Knowledge Management with gamification elements. Boost motivation and achieve growth as you engage with your PKM.",
   "main": "main.js",
   "scripts": {

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -15,6 +15,10 @@ I develop this plugin as a hobby, spending my free time doing this. If you find 
 
 It would mean a lot to me.
 `,
+"0.0.106": 	`
+## new
+- define in settings if you want use an include logic or exclude logic when using tags and folders when initializing the game.
+`,
 "0.0.105": 	`
 ## Fix
 - show init command on fresh installation

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -25,8 +25,8 @@ It would mean a lot to me.
 |No tags, no folders | ✅ All files (except system) | ✅ All files (except system)|
 |Tags specified, no folders | ✅ Only files with those tags | ✅ Excludes files with those tags|
 |Folders specified, no tags | ✅ Only files in those folders | ✅ Excludes files in those folders|
-|Both specified | ✅ Must match both (AND) | ❌ Excluded if matches either (OR)|
-|.trash / .obsidian | ❌ Always excluded | ❌ Always excluded|
+|Both specified | ✅ Must match both (AND) | ❌ Excluded if matches either (OR)|
+|.trash / .obsidian | ❌ Always excluded | ❌ Always excluded|
 ## fix
 - when initializing game, data.json could be empty and all init xp lost
 `,
@@ -68,7 +68,7 @@ It would mean a lot to me.
 - Creating and attaching "style" elements is not allowed. 
 `,
 "0.0.97": `
-This release deals fully with the representation of the boosters and ingredients. Beside adding graphical representations for them, also the style is now improved. Have a look at the crafting table!
+This release deals fully with the representation of the boosters and ingredients. Besides adding graphical representations for them, also the style is now improved. Have a look at the crafting table!
 ## New
 - visual redesigned booster area with symbols
 - Introducing ingredient symbols

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -18,6 +18,17 @@ It would mean a lot to me.
 "0.0.106": 	`
 ## new
 - define in settings if you want use an include logic or exclude logic when using tags and folders when initializing the game.
+
+
+|Scenario | Include Mode (false) | Exclude Mode (true)|
+|-- | -- | --|
+|No tags, no folders | ✅ All files (except system) | ✅ All files (except system)|
+|Tags specified, no folders | ✅ Only files with those tags | ✅ Excludes files with those tags|
+|Folders specified, no tags | ✅ Only files in those folders | ✅ Excludes files in those folders|
+|Both specified | ✅ Must match both (AND) | ❌ Excluded if matches either (OR)|
+|.trash / .obsidian | ❌ Always excluded | ❌ Always excluded|
+## fix
+- when initializing game, data.json could be empty and all init xp lost
 `,
 "0.0.105": 	`
 ## Fix

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,5 +1,5 @@
 import { Badge } from '../badges'
-export const PLUGIN_VERSION = '0.0.105';
+export const PLUGIN_VERSION = '0.0.106';
 export const pointsNoteMajurity = 100;
 export const pointsMajurity = 10;
 export const pointsForDailyChallenge = 500;

--- a/src/main.ts
+++ b/src/main.ts
@@ -589,12 +589,15 @@ export default class gamification extends Plugin {
 		new ModalInformationbox(this.app, `The Game is now reset.`).open();
     }
 
-
     private async initializeGame(statusbarGamification: HTMLSpanElement) {
 		this.mediator.setSettingString('gamificationStartDate', format(new Date(), 'yyyy-MM-dd'));
 		await this.saveSettings();
 
-		const fileCountMap: TFile[] | null = await this.maturityCalculator.getFileMap(this.app, this.mediator.getSettingString('tagsExclude'), this.mediator.getSettingString('folderExclude'));
+		const fileCountMap: TFile[] | null = await this.maturityCalculator.getFileMap(
+			this.app, this.mediator.getSettingString('tagsExclude'),
+			this.mediator.getSettingString('folderExclude'),
+			this.mediator.getSettingBoolean('selectionLogicForRating')
+		);
 		if (fileCountMap !== null) {
 			let pointsReceived = 0; // To have one message at the end, how many points received
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -591,7 +591,7 @@ export default class gamification extends Plugin {
 
     private async initializeGame(statusbarGamification: HTMLSpanElement) {
 		this.mediator.setSettingString('gamificationStartDate', format(new Date(), 'yyyy-MM-dd'));
-		await this.saveSettings();
+		await this.mediator.saveSettings();
 
 		const fileCountMap: TFile[] | null = await this.maturityCalculator.getFileMap(
 			this.app, this.mediator.getSettingString('tagsExclude'),

--- a/src/maturitycalculation.ts
+++ b/src/maturitycalculation.ts
@@ -476,46 +476,66 @@ export class MaturityCalculator {
 	};
 
 
-	public getFileMap = async (app: App, excludeTag: string, excludeFolder: string): Promise<TFile[] | null> => {
+	public getFileMap = async (
+		app: App,
+		excludeTag: string,
+		excludeFolder: string,
+		includeMode: boolean,  // ← NEW parameter: true=exclude, false=include
+	): Promise<TFile[] | null> => {
 		try {
 			const { vault } = app;
 
-			// 1. Process Tags to ignore
-			let excludedSubstrings: string[] = [];
+			// 1. Process Tags
+			let filterTags: string[] = [];
 			if (excludeTag && excludeTag.trim().length > 0) {
-				excludedSubstrings = excludeTag.split(',').map(t => t.trim());
+				filterTags = excludeTag.split(',').map(t => t.trim());
 			}
 
-			// 2. Process Folders to ignore
-			let excludedFolders: string[] = [];
+			// 2. Process Folders
+			let filterFolders: string[] = [];
 			if (excludeFolder && excludeFolder.trim().length > 0) {
-				excludedFolders = excludeFolder.split(',').map(f => f.trim());
+				filterFolders = excludeFolder.split(',').map(f => f.trim());
 			}
 
-			// 3. FIX: Use dynamic configDir instead of hardcoded '.obsidian'
-			// Also include the trash folder
-			excludedFolders.push(app.vault.configDir, '.trash');
+			// 3. Always exclude system folders (regardless of mode)
+			const systemFolders = [app.vault.configDir, '.trash'];
 
 			const fileArray: TFile[] = [];
 			const files = await vault.getMarkdownFiles();
 
 			for (const file of files) {
-				// A: Check if the file is inside an excluded folder
-				// We use startsWith to ensure we only catch folders, not files with similar names
-				const isInExcludedFolder = excludedFolders.some(folder =>
+				// A: ALWAYS skip system folders
+				const isInSystemFolder = systemFolders.some(folder =>
+					file.path === folder || file.path.startsWith(folder + '/')
+				);
+				if (isInSystemFolder) continue;
+
+				// B: Check folder & tag filtering based on mode
+				const fileContents = await app.vault.read(file);
+
+				const isInFilteredFolder = filterFolders.some(folder =>
 					file.path === folder || file.path.startsWith(folder + '/')
 				);
 
-				if (isInExcludedFolder) continue; // Skip this file immediately
+				const hasFilteredTag = filterTags.length > 0 &&
+					filterTags.some(tag => fileContents.includes(tag));
 
-				// B: Check file content for excluded tags
-				// Optimization: Only read the file if we haven't already excluded it by folder
-				const fileContents = await app.vault.read(file);
-				const hasExcludedTag = excludedSubstrings.length > 0 &&
-					excludedSubstrings.some(substring => fileContents.includes(substring));
-
-				if (!hasExcludedTag) {
+				if (includeMode) {
+					// 🟢 EXCLUDE MODE (selectionLogicForRating = true)
+					// Skip files matching the filters
+					if (isInFilteredFolder) continue;
+					if (hasFilteredTag) continue;
 					fileArray.push(file);
+
+				} else {
+					// 🔵 INCLUDE MODE (selectionLogicForRating = false)
+					// Only keep files that match the filters
+					const matchesFolder = filterFolders.length === 0 || isInFilteredFolder;
+					const matchesTag = filterTags.length === 0 || hasFilteredTag;
+
+					if (matchesFolder && matchesTag) {
+						fileArray.push(file);
+					}
 				}
 			}
 
@@ -525,6 +545,7 @@ export class MaturityCalculator {
 			return null;
 		}
 	};
+
 
 
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -108,7 +108,8 @@ export const defaultSettings: Partial<ISettings> = {
   avatarPicture: "U2FsdGVkX18zJk4m8pNboYxTAVmT5KytaqxAsTw/50I=",
   colorBarReceived: "U2FsdGVkX19GLvJtvLLriVKTDDLMVt+P7ysHKoOcIb0=",
   colorBarToGo: "U2FsdGVkX1/8uFFZ/kZeDb2YWMKM8h8rzssbPWBGZ7c=",
-  showProfileLeaf: "U2FsdGVkX1+7lWe/h95uqzgl27JBGW2iki7sBwk44YQ="
+  showProfileLeaf: "U2FsdGVkX1+7lWe/h95uqzgl27JBGW2iki7sBwk44YQ=",
+  selectionLogicForRating: "U2FsdGVkX1/1/9F4IhoD0pKoms3dszIeOl/RhIVuAAY="
 };
 
 export interface DynamicSettings {
@@ -208,6 +209,7 @@ export interface ISettings extends DynamicSettings{
   colorBarReceived: string
   colorBarToGo: string
   showProfileLeaf: string
+  selectionLogicForRating: string
 	//[key: string]: number | string | boolean | MomentInput;
 }
 
@@ -308,6 +310,7 @@ export class GamificationPluginSettings extends PluginSettingTab {
 	public colorBarReceived: string;
 	public colorBarToGo: string;
     public showProfileLeaf: string;
+	public selectionLogicForRating: string;
 
 	constructor(app: App, plugin: gamification, mediator: GamificationMediator) {
 		super(app, plugin as never);
@@ -334,32 +337,6 @@ export class GamificationPluginSettings extends PluginSettingTab {
 					}),
 			);
 
-		new Setting(containerEl)
-			.setName('#tags to ignore')
-			.setDesc('Enter tags without # and separate with ", ". Include nested tags.')
-			.addText(text =>
-				text
-					.setPlaceholder('Enter your tag1, tag2/subtag, …')
-					.setValue(this.mediator.getSettingString('tagsExclude'))
-					.onChange(async (value) => {
-						this.mediator.setSettingString('tagsExclude', value);
-						await this.mediator.saveSettings();
-					}),
-			);
-
-
-		new Setting(containerEl)
-			.setName('Folder to ignore')
-			.setDesc('Enter folders whose content shall be ignored. Separate with ", ".')
-			.addText(text =>
-				text
-					.setPlaceholder('Enter your folder1, folder2, …')
-					.setValue(this.mediator.getSettingString('folderExclude'))
-					.onChange(async (value) => {
-						this.mediator.setSettingString('folderExclude', value);
-						await this.mediator.saveSettings();
-					}),
-			);
 
 		new Setting(containerEl)
 			.setName('Show profile leaf')
@@ -416,6 +393,46 @@ export class GamificationPluginSettings extends PluginSettingTab {
 						this.mediator.setSettingString('avatarPicture', value);
 						await this.mediator.saveSettings();
 						this.mediator.updateProfileLeafPic();
+					}),
+			);
+
+		new Setting(containerEl).setName('Selection').setHeading().setDesc("If you don't want to include all files, you can specify this here. You can choose if you follow the principle to tell what to include, or what to exclude.")
+
+		new Setting(containerEl)
+			.setName('Include logic or exclude logic')
+			.setDesc('You can define if you want to follow an include logic `off` or an exclude logic `on`')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.mediator.getSettingBoolean('selectionLogicForRating'))
+					.onChange(async (value) => {
+						this.mediator.setSettingBoolean('selectionLogicForRating', value);
+						await this.mediator.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName('#tags to include/exclude, depending on setting')
+			.setDesc('Enter tags without # and separate with ", ". Include nested tags.')
+			.addText(text =>
+				text
+					.setPlaceholder('Enter your tag1, tag2/subtag, …')
+					.setValue(this.mediator.getSettingString('tagsExclude'))
+					.onChange(async (value) => {
+						this.mediator.setSettingString('tagsExclude', value);
+						await this.mediator.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName('Folder to include/exclude, depending on setting')
+			.setDesc('Enter folders whose content shall be included or ignored. Separate with ", ".')
+			.addText(text =>
+				text
+					.setPlaceholder('Enter your folder1, folder2, …')
+					.setValue(this.mediator.getSettingString('folderExclude'))
+					.onChange(async (value) => {
+						this.mediator.setSettingString('folderExclude', value);
+						await this.mediator.saveSettings();
 					}),
 			);
 


### PR DESCRIPTION
Hot-fix to save data after initializing correctly. With release 0.0.105 it could occur to not saving the data. 

---

Adding for initializing the game if you want to use an exclude logic, or an include logic for tags and folders. 


|Scenario | Include Mode (false) | Exclude Mode (true)|
|-- | -- | --|
|No tags, no folders | ✅ All files (except system) | ✅ All files (except system)|
|Tags specified, no folders | ✅ Only files with those tags | ✅ Excludes files with those tags|
|Folders specified, no tags | ✅ Only files in those folders | ✅ Excludes files in those folders|
|Both specified | ✅ Must match both (AND) | ❌ Excluded if matches either (OR)|
|.trash / .obsidian | ❌ Always excluded | ❌ Always excluded|
